### PR TITLE
Allow access to ctor args for the formsets

### DIFF
--- a/demo/blocks/views.py
+++ b/demo/blocks/views.py
@@ -1,11 +1,12 @@
 from django.core.urlresolvers import reverse
+from django.forms.models import inlineformset_factory
 from django.views.generic import (
     ListView,
     CreateView,
     UpdateView,
 )
 
-from nested_formset import nested_formset_factory
+from nested_formset import nestedformset_factory
 
 from blocks import models
 
@@ -32,10 +33,13 @@ class EditBuildingsView(UpdateView):
 
     def get_form_class(self):
 
-        return nested_formset_factory(
+        return nestedformset_factory(
             models.Block,
             models.Building,
-            models.Tenant,
+            nested_formset=inlineformset_factory(
+                models.Building,
+                models.Tenant
+            )
         )
 
     def get_success_url(self):

--- a/src/nested_formset/__init__.py
+++ b/src/nested_formset/__init__.py
@@ -1,6 +1,9 @@
+import django
+
 from django.forms.models import (
     BaseInlineFormSet,
     inlineformset_factory,
+    ModelForm,
 )
 
 
@@ -43,17 +46,35 @@ class BaseNestedFormset(BaseInlineFormSet):
         return result
 
 
-def nested_formset_factory(parent_model, child_model, grandchild_model):
+def nestedformset_factory(parent_model, model, nested_formset, form=ModelForm,
+                          formset=BaseNestedFormset, fk_name=None, fields=None,
+                          exclude=None, extra=3, can_order=False,
+                          can_delete=True, max_num=None,
+                          formfield_callback=None, widgets=None,
+                          validate_max=False, localized_fields=None,
+                          labels=None, help_texts=None, error_messages=None):
+    kwargs = {
+        'form': form,
+        'formfield_callback': formfield_callback,
+        'formset': formset,
+        'extra': extra,
+        'can_delete': can_delete,
+        'can_order': can_order,
+        'fields': fields,
+        'exclude': exclude,
+        'max_num': max_num,
+    }
 
-    parent_child = inlineformset_factory(
-        parent_model,
-        child_model,
-        formset=BaseNestedFormset,
-    )
+    if django.VERSION >= (1, 6):
+        kwargs.update({
+            'widgets': widgets,
+            'validate_max': validate_max,
+            'localized_fields': localized_fields,
+            'labels': labels,
+            'help_texts': help_texts,
+            'error_messages': error_messages,
+        })
 
-    parent_child.nested_formset_class = inlineformset_factory(
-        child_model,
-        grandchild_model,
-    )
-
-    return parent_child
+    NestedFormSet = inlineformset_factory(parent_model, model, **kwargs)
+    NestedFormSet.nested_formset_class = nested_formset
+    return NestedFormSet

--- a/src/nested_formset/tests/test_factory.py
+++ b/src/nested_formset/tests/test_factory.py
@@ -1,27 +1,29 @@
 from unittest import TestCase
 
-from django.forms.models import BaseInlineFormSet
+from django.forms.models import BaseInlineFormSet, inlineformset_factory
 from nested_formset.tests import models as test_models
 
-from nested_formset import nested_formset_factory
+from nested_formset import nestedformset_factory
 
 
 class FactoryTests(TestCase):
 
     def test_factory_calls(self):
 
-        nested_formset = nested_formset_factory(
+        child_formset = inlineformset_factory(test_models.Building, test_models.Tenant)
+        nestedformset_factory(
             test_models.Block,
             test_models.Building,
-            test_models.Tenant,
+            nested_formset=child_formset,
         )
 
     def test_factory_returns_formset(self):
 
-        nested_formset = nested_formset_factory(
+        child_formset = inlineformset_factory(test_models.Building, test_models.Tenant)
+        nested_formset = nestedformset_factory(
             test_models.Block,
             test_models.Building,
-            test_models.Tenant,
+            nested_formset=child_formset,
         )
 
         self.assertTrue(issubclass(nested_formset, BaseInlineFormSet))

--- a/src/nested_formset/tests/test_instantiation.py
+++ b/src/nested_formset/tests/test_instantiation.py
@@ -1,19 +1,20 @@
 from unittest import TestCase
 
-from django.forms.models import BaseInlineFormSet
+from django.forms.models import BaseInlineFormSet, inlineformset_factory
 from nested_formset.tests import models as test_models
 
-from nested_formset import nested_formset_factory
+from nested_formset import nestedformset_factory
 
 
 class InstantiationTests(TestCase):
 
     def setUp(self):
 
-        self.formset_class = nested_formset_factory(
+        child_formset = inlineformset_factory(test_models.Building, test_models.Tenant)
+        self.formset_class = nestedformset_factory(
             test_models.Block,
             test_models.Building,
-            test_models.Tenant,
+            nested_formset=child_formset,
         )
 
     def test_takes_parent_discovers_children(self):

--- a/src/nested_formset/tests/test_save.py
+++ b/src/nested_formset/tests/test_save.py
@@ -1,20 +1,21 @@
 from django.test import TestCase
 
-from django.forms.models import BaseInlineFormSet
+from django.forms.models import inlineformset_factory
 from nested_formset.tests import models as test_models
 from nested_formset.tests.util import get_form_data
 
-from nested_formset import nested_formset_factory
+from nested_formset import nestedformset_factory
 
 
 class EditTests(TestCase):
 
     def setUp(self):
 
-        self.formset_class = nested_formset_factory(
+        child_formset = inlineformset_factory(test_models.Building, test_models.Tenant)
+        self.formset_class = nestedformset_factory(
             test_models.Block,
             test_models.Building,
-            test_models.Tenant,
+            nested_formset=child_formset,
         )
 
         self.block = test_models.Block.objects.create()
@@ -89,10 +90,11 @@ class CreationTests(TestCase):
 
     def setUp(self):
 
-        self.formset_class = nested_formset_factory(
+        child_formset = inlineformset_factory(test_models.Building, test_models.Tenant)
+        self.formset_class = nestedformset_factory(
             test_models.Block,
             test_models.Building,
-            test_models.Tenant,
+            nested_formset=child_formset,
         )
 
         self.block = test_models.Block.objects.create()
@@ -190,10 +192,11 @@ class DeleteTests(TestCase):
 
     def setUp(self):
 
-        self.formset_class = nested_formset_factory(
+        child_formset = inlineformset_factory(test_models.Building, test_models.Tenant)
+        self.formset_class = nestedformset_factory(
             test_models.Block,
             test_models.Building,
-            test_models.Tenant,
+            nested_formset=child_formset,
         )
 
         self.block = test_models.Block.objects.create()

--- a/src/nested_formset/tests/test_validation.py
+++ b/src/nested_formset/tests/test_validation.py
@@ -1,20 +1,21 @@
 from unittest import TestCase
 
-from django.forms.models import BaseInlineFormSet
+from django.forms.models import inlineformset_factory
 from nested_formset.tests import models as test_models
 from nested_formset.tests.util import get_form_data
 
-from nested_formset import nested_formset_factory
+from nested_formset import nestedformset_factory
 
 
 class ValidationTests(TestCase):
 
     def setUp(self):
 
-        self.formset_class = nested_formset_factory(
+        child_formset = inlineformset_factory(test_models.Building, test_models.Tenant)
+        self.formset_class = nestedformset_factory(
             test_models.Block,
             test_models.Building,
-            test_models.Tenant,
+            nested_formset=child_formset,
         )
 
     def test_is_valid_calls_is_valid_on_nested(self):


### PR DESCRIPTION
The inner formset is a normal InlineFormSet and should now be created by the caller and passed as
nested_formset. When the caller creates it she can customize it to her heart's content. It also
allows for more than one nesting level.

The outer formset can be configured by passing the same options to nestedformset_factory as can be
passed to inlineformset_factory.

Lastly, nested_formset_factory has been renamed to nestedformset_factory for consistency with
inlineformset_factory.

This is a little bit all-in-one. Let me know what you think. Also, do you intend to release the package on pypi?
