### PR TITLE
Added missing keyword arguments to factory and accompanying tests

### DIFF
--- a/src/nested_formset/__init__.py
+++ b/src/nested_formset/__init__.py
@@ -1,5 +1,3 @@
-import django
-
 from django.forms.models import (
     BaseInlineFormSet,
     inlineformset_factory,

--- a/src/nested_formset/__init__.py
+++ b/src/nested_formset/__init__.py
@@ -98,11 +98,6 @@ def nestedformset_factory(parent_model, model, nested_formset,
             for field in model._meta.local_fields
         ]
 
-    kwargs.update({
-        'min_num': min_num,
-        'validate_min': validate_min,
-    })
-
     NestedFormSet = inlineformset_factory(
         parent_model,
         model,

--- a/src/nested_formset/__init__.py
+++ b/src/nested_formset/__init__.py
@@ -98,11 +98,10 @@ def nestedformset_factory(parent_model, model, nested_formset,
             for field in model._meta.local_fields
         ]
 
-    if django.VERSION >= (1, 7):
-        kwargs.update({
-            'min_num': min_num,
-            'validate_min': validate_min,
-        })
+    kwargs.update({
+        'min_num': min_num,
+        'validate_min': validate_min,
+    })
 
     NestedFormSet = inlineformset_factory(
         parent_model,

--- a/src/nested_formset/__init__.py
+++ b/src/nested_formset/__init__.py
@@ -73,20 +73,23 @@ def nestedformset_factory(parent_model, model, nested_formset,
                           min_num=None, validate_min=None):
     kwargs = {
         'form': form,
-        'formfield_callback': formfield_callback,
         'formset': formset,
-        'extra': extra,
-        'can_delete': can_delete,
-        'can_order': can_order,
+        'fk_name': fk_name,
         'fields': fields,
         'exclude': exclude,
+        'extra': extra,
+        'can_order': can_order,
+        'can_delete': can_delete,
         'max_num': max_num,
-            'widgets': widgets,
-            'validate_max': validate_max,
-            'localized_fields': localized_fields,
-            'labels': labels,
-            'help_texts': help_texts,
-            'error_messages': error_messages,
+        'formfield_callback': formfield_callback,
+        'widgets': widgets,
+        'validate_max': validate_max,
+        'localized_fields': localized_fields,
+        'labels': labels,
+        'help_texts': help_texts,
+        'error_messages': error_messages,
+        'min_num': min_num,
+        'validate_min': validate_min
     }
 
     if kwargs['fields'] is None:

--- a/src/nested_formset/tests/test_factory.py
+++ b/src/nested_formset/tests/test_factory.py
@@ -1,5 +1,6 @@
-from unittest import TestCase
+from unittest import TestCase, skipIf
 
+import django
 from django.forms.models import BaseInlineFormSet, inlineformset_factory
 from nested_formset.tests import models as test_models
 
@@ -60,3 +61,61 @@ class FactoryTests(TestCase):
             tuple(nested_formset.form.base_fields.keys()),
             ('block',),
         )
+        
+    def test_fk_name_for_factory(self):
+        
+        fk_name = 'block'
+        # Should pass because fk_name is valid
+        nested_formset = nestedformset_factory(
+            test_models.Block,
+            test_models.Building,
+            nested_formset=self.child_formset,
+            fk_name='block'
+        )()
+        # Fails because address is not fk 
+        with self.assertRaises(ValueError):
+            nested_formset = nestedformset_factory(
+                test_models.Block,
+                test_models.Building,
+                nested_formset=self.child_formset,
+                fk_name='address'
+            )()
+        
+    def test_min_num_for_factory(self):
+        
+        num = 3
+        nested_formset = nestedformset_factory(
+            test_models.Block,
+            test_models.Building,
+            nested_formset=self.child_formset,
+            min_num=num
+        )
+        
+        if django.VERSION >= (1, 7):
+            self.assertEqual(
+                num,
+                nested_formset.min_num
+            )
+        else:
+            with self.assertRaises(AttributeError):
+                nested_formset.min_num
+        
+    def test_validate_min_for_factory(self):
+        # Default is False
+        validate_min = True
+        nested_formset = nestedformset_factory(
+            test_models.Block,
+            test_models.Building,
+            nested_formset=self.child_formset,
+            validate_min=validate_min
+        )
+        
+        if django.VERSION >= (1,7 ):
+            self.assertEqual(
+                validate_min,
+                nested_formset.validate_min
+            )
+        else:
+            with self.assertRaises(AttributeError):
+                nested_formset.validate_min
+        

--- a/src/nested_formset/tests/test_factory.py
+++ b/src/nested_formset/tests/test_factory.py
@@ -1,4 +1,4 @@
-from unittest import TestCase, skipIf
+from unittest import TestCase
 
 import django
 from django.forms.models import BaseInlineFormSet, inlineformset_factory
@@ -90,15 +90,12 @@ class FactoryTests(TestCase):
             nested_formset=self.child_formset,
             min_num=num
         )
-        
-        if django.VERSION >= (1, 7):
-            self.assertEqual(
-                num,
-                nested_formset.min_num
-            )
-        else:
-            with self.assertRaises(AttributeError):
-                nested_formset.min_num
+
+        self.assertEqual(
+            num,
+            nested_formset.min_num
+        )
+
         
     def test_validate_min_for_factory(self):
         # Default is False
@@ -110,12 +107,8 @@ class FactoryTests(TestCase):
             validate_min=validate_min
         )
         
-        if django.VERSION >= (1,7 ):
-            self.assertEqual(
-                validate_min,
-                nested_formset.validate_min
-            )
-        else:
-            with self.assertRaises(AttributeError):
-                nested_formset.validate_min
+        self.assertEqual(
+            validate_min,
+            nested_formset.validate_min
+        )
         


### PR DESCRIPTION
I just added keyword arguments that for some reason got left out of the factory function definition (fk_name, min_num, validate_min), and added tests making sure they are getting passed in now.

I also reordered the kwargs dictionary to match the order of the arguments in the function call. Seemed to make more sense this way.